### PR TITLE
Add method override_address() to change the address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,11 @@ impl<IO: DfuIo> DfuSansIo<IO> {
             },
         })
     }
+
+    /// Consume the object and return its [`DfuIo`] and address.
+    pub fn into_parts(self) -> (IO, u32) {
+        (self.io, self.address)
+    }
 }
 
 /// DFU Status.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -40,7 +40,7 @@ where
     }
 
     /// Override the address.
-    pub fn set_address(self, address: u32) -> Self {
+    pub fn override_address(self, address: u32) -> Self {
         let (io, _) = self.dfu.into_parts();
 
         Self {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -38,6 +38,16 @@ where
             ..self
         }
     }
+
+    /// Override the address.
+    pub fn set_address(self, address: u32) -> Self {
+        let (io, _) = self.dfu.into_parts();
+
+        Self {
+            dfu: DfuSansIo::new(io, address),
+            ..self
+        }
+    }
 }
 
 impl<IO, E> DfuSync<IO, E>


### PR DESCRIPTION
I'm not entirely sure if this is useful/wise. Maybe we should add a warning.

Fixes #7