### PR TITLE
Fix clearing status not working

### DIFF
--- a/src/get_status.rs
+++ b/src/get_status.rs
@@ -98,11 +98,6 @@ impl<T: ChainedCommand<Arg = GetStatusMessage>> GetStatusRecv<T> {
         let i_string = bytes.get_u8();
         log::trace!("Device i string: {:#x}", i_string);
 
-        status.raise_error()?;
-        state.raise_error()?;
-
-        log::trace!("Device is not in error status nor error state");
-
         Ok(self.chained_command.chain(GetStatusMessage {
             status,
             poll_timeout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,16 +186,6 @@ pub enum Status {
     Other(u8),
 }
 
-impl Status {
-    pub(crate) fn raise_error(&self) -> Result<(), Error> {
-        if !matches!(self, Status::Ok | Status::Other(_)) {
-            Err(Error::StatusError(*self))
-        } else {
-            Ok(())
-        }
-    }
-}
-
 /// DFU State.
 ///
 /// Note: not the same as status!
@@ -225,16 +215,6 @@ pub enum State {
     DfuError,
     /// Other ({0}).
     Other(u8),
-}
-
-impl State {
-    pub(crate) fn raise_error(&self) -> Result<(), Error> {
-        if matches!(self, State::DfuError) {
-            Err(Error::StateError(*self))
-        } else {
-            Ok(())
-        }
-    }
 }
 
 /// A trait for commands that be chained into another.


### PR DESCRIPTION
Clearing status wasn't working because the error is raised before the status
can be cleared.

I don't think there is any reason to check the status in the GetStatus step... the checked should always be handled on the receiving step after getting the status (which is already done properly).