### PR TITLE
Support both dfu 1.1 and dfuse protocols

### DIFF
--- a/src/get_status.rs
+++ b/src/get_status.rs
@@ -62,7 +62,8 @@ impl<T: ChainedCommand<Arg = GetStatusMessage>> GetStatusRecv<T> {
         log::trace!("Device status: {:?}", status);
         let poll_timeout = bytes.get_uint_le(3);
         log::trace!("Poll timeout: {}", poll_timeout);
-        let state = bytes.get_u8().into();
+        let state: State = bytes.get_u8().into();
+        let state = state.for_status();
         log::trace!("Device state: {:?}", state);
         let i_string = bytes.get_u8();
         log::trace!("Device i string: {:#x}", i_string);

--- a/tests/download.rs
+++ b/tests/download.rs
@@ -13,10 +13,10 @@ fn setup() {
 
 fn test_simple_download(mock: MockIO) {
     let firmware = b"thisisnotafirmwareorisit";
-    let mut dfu = dfu_core::sync::DfuSync::new(mock, 0x0);
+    let mut dfu = dfu_core::sync::DfuSync::new(mock);
 
     dfu.download_from_slice(firmware).unwrap();
-    let (mock, _) = dfu.into_parts();
+    let mock = dfu.into_inner();
 
     let descriptor = mock.functional_descriptor();
 
@@ -64,6 +64,50 @@ fn will_detach_and_manifestation_toleration() {
     let mock = mock::MockIOBuilder::default()
         .will_detach(true)
         .manifestation_tolerant(true)
+        .build();
+    test_simple_download(mock);
+}
+
+#[test]
+fn no_will_detach_and_no_manifestation_toleration_dfuse() {
+    setup();
+    let mock = mock::MockIOBuilder::default()
+        .will_detach(false)
+        .manifestation_tolerant(false)
+        .dfuse(true)
+        .build();
+    test_simple_download(mock);
+}
+
+#[test]
+fn will_detach_and_no_manifestation_toleration_dfuse() {
+    setup();
+    let mock = mock::MockIOBuilder::default()
+        .manifestation_tolerant(false)
+        .will_detach(true)
+        .dfuse(true)
+        .build();
+    test_simple_download(mock);
+}
+
+#[test]
+fn no_will_detach_and_manifestation_toleration_dfuse() {
+    setup();
+    let mock = mock::MockIOBuilder::default()
+        .will_detach(false)
+        .manifestation_tolerant(true)
+        .dfuse(true)
+        .build();
+    test_simple_download(mock);
+}
+
+#[test]
+fn will_detach_and_manifestation_toleration_dfuse() {
+    setup();
+    let mock = mock::MockIOBuilder::default()
+        .will_detach(true)
+        .manifestation_tolerant(true)
+        .dfuse(true)
         .build();
     test_simple_download(mock);
 }


### PR DESCRIPTION
Split protocol specific data for both dfu and dfuse into their own enum variants and handle the differences. The IO implementation is now responsible for a reference to protocol specific data rather then providing a memory layout (which is only for dfuse).

To make that a bit simpler for IO implementations the code from dfu-libusb was integrated to do the differentiation between the protocols and the parsing of dfuse data.

Also add helpers for sending a detach request as well as a usb reset without having to pull out the IO objects

Fixes #17

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>