### PR TITLE
Correct page erasure sizes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,26 +181,17 @@ impl<IO: DfuIo> DfuSansIo<IO> {
             DfuProtocol::Dfu => (download::ProtocolData::Dfu, length),
             DfuProtocol::Dfuse {
                 address,
-                ref memory_layout,
+                memory_layout,
                 ..
-            } => {
-                let (&page_size, rest_memory_layout) = memory_layout
-                    .as_ref()
-                    .split_first()
-                    .ok_or(Error::NoSpaceLeft)?;
-                log::trace!("Rest of memory layout: {:?}", rest_memory_layout);
-                log::trace!("Page size: {:?}", page_size);
-
-                (
-                    download::ProtocolData::Dfuse(download::DfuseProtocolData {
-                        address: *address,
-                        erased_pos: *address,
-                        address_set: false,
-                        page_size,
-                    }),
-                    address.checked_add(length).ok_or(Error::NoSpaceLeft)?,
-                )
-            }
+            } => (
+                download::ProtocolData::Dfuse(download::DfuseProtocolData {
+                    address: *address,
+                    erased_pos: *address,
+                    address_set: false,
+                    memory_layout: memory_layout.as_ref(),
+                }),
+                address.checked_add(length).ok_or(Error::NoSpaceLeft)?,
+            ),
         };
 
         Ok(get_status::GetStatus {

--- a/tests/download.rs
+++ b/tests/download.rs
@@ -12,10 +12,15 @@ fn setup() {
 }
 
 fn test_simple_download(mock: MockIO) {
-    let firmware = b"thisisnotafirmwareorisit";
+    let size = mock.size();
+    let mut firmware = Vec::with_capacity(size as usize);
+    for i in 0..size {
+        firmware.push(i as u8);
+    }
+
     let mut dfu = dfu_core::sync::DfuSync::new(mock);
 
-    dfu.download_from_slice(firmware).unwrap();
+    dfu.download_from_slice(&firmware).unwrap();
     let mock = dfu.into_inner();
 
     let descriptor = mock.functional_descriptor();


### PR DESCRIPTION
In commit 4dc4087f76 the page size for erasure was refactored to be only determined once however; That failed to take into account that the page sizes can differ in different zones. So refactor once again to be closer to the original approach of memory layout tracking.

This also updates the test mock to have two zones for dfuse with different page sizes and ensures that erasures are always properly done at page boundaries.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>