### PR TITLE
Ensure full transfer size is used whenever possible

### DIFF
--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -82,6 +82,7 @@ impl MockIOBuilder {
             erased: Vec::new(),
             busy: 0,
             was_reset: false,
+            saw_incomplete_write: false,
         });
 
         MockIO {
@@ -100,6 +101,7 @@ struct MockIOInner {
     erased: Vec<(u32, u32)>,
     busy: u16,
     was_reset: bool,
+    saw_incomplete_write: bool,
 }
 
 pub struct MockIO {
@@ -169,6 +171,13 @@ impl MockIO {
         assert_eq!(inner.writes, blocknum);
         inner.busy = inner.writes % 4;
         inner.writes += 1;
+        assert!(
+            !inner.saw_incomplete_write,
+            "Seen incomplete write before final write",
+        );
+        if buffer.len() != self.functional_descriptor.transfer_size as usize {
+            inner.saw_incomplete_write = true;
+        }
         inner.download.extend_from_slice(buffer);
     }
 


### PR DESCRIPTION
Some dfu implementations misbehave if a DFUDNLOAD (apart from the last one) doesn't match the full transfer size as declared by the functional descriptor.

The current usage of a BufReader doesn't guarantee this as the underlying reader may not fully fill the buffer; This is uncommon/unlikely when reading from a local filesystem, but very likely when reading from a network stream.

Introduce a simple helper buffer which fully refills it's buffer from the underlying reader, but otherwise matches the use api from bufreader to get the intended semantics.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>