### PR TITLE
fix: the last DFU state of non-manifestation tolerant devices should be `DfuManifestWaitReset`

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -284,7 +284,7 @@ impl<'dfu> DownloadChunk<'dfu> {
             if self.descriptor.manifestation_tolerant {
                 (State::DfuManifest, State::DfuIdle)
             } else {
-                (State::DfuManifest, State::DfuManifest)
+                (State::DfuManifest, State::DfuManifestWaitReset)
             }
         } else {
             (State::DfuDnbusy, State::DfuDnloadIdle)

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -318,7 +318,7 @@ impl DfuIo for MockIO {
             (Request::DFU_GETSTATUS, State::DfuManifestSync) => {
                 if !self.functional_descriptor.manifestation_tolerant {
                     self.update_state(State::DfuManifestWaitReset);
-                    self.status_request(buffer, State::DfuManifest)
+                    self.status_request(buffer, State::DfuManifestWaitReset)
                 } else if self.still_busy() {
                     self.status_request(buffer, State::DfuManifest)
                 } else {


### PR DESCRIPTION
I ran into the following error while trying to update a non-manifestation tolerant device which uses [embassy-usb-dfu](https://docs.embassy.dev/embassy-usb-dfu/git/dfu/index.html) in the firmware:
```
called `Result::unwrap()` on an `Err` value: Dfu(InvalidState { got: DfuManifestWaitReset, expected: DfuManifest })
```
Therefore, there must be a mistake either in this library or in `embassy-usb-dfu`. 
By looking at other implementations like [this one](https://github.com/vitalyvb/usbd-dfu/blob/main/src/class.rs#L932), I think that the mistake is in `dfu-core`.
Could you please double check?