### PR TITLE
Allow block_num to wrap per DFU spec 6.1.1

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -303,8 +303,7 @@ impl<'dfu> DownloadChunk<'dfu> {
                 protocol: self.protocol,
                 block_num: self
                     .block_num
-                    .checked_add(1)
-                    .ok_or(Error::MaximumChunksExceeded)?,
+                    .wrapping_add(1),
                 eof: bytes.is_empty(),
             },
         );

--- a/src/download.rs
+++ b/src/download.rs
@@ -301,9 +301,7 @@ impl<'dfu> DownloadChunk<'dfu> {
                     .checked_add(len)
                     .ok_or(Error::MaximumTransferSizeExceeded)?,
                 protocol: self.protocol,
-                block_num: self
-                    .block_num
-                    .wrapping_add(1),
+                block_num: self.block_num.wrapping_add(1),
                 eof: bytes.is_empty(),
             },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use thiserror::Error;
 #[derive(Debug, Display)]
 #[cfg_attr(any(feature = "std", test), derive(Error))]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum Error {
     /// The size of the data being transferred exceeds the DFU capabilities.
     OutOfCapabilities,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,6 @@ pub enum Error {
     MaximumTransferSizeExceeded,
     /// Erasing limit reached.
     EraseLimitReached,
-    /// Maximum number of chunks exceeded.
-    MaximumChunksExceeded,
     /// Not enough space on device.
     NoSpaceLeft,
     /// Unrecognized status code: {0}


### PR DESCRIPTION
 `Per the DFU specification 6.1.1, wBlockNum is a block sequence number that increments each time a block is transferred, wrapping to zero from 65,535.` 

Remove the erroneous MaximumChunksExceeded error and use wrapping_add to correctly implement the specified behavior.

Removed that Error variant as it was not used anywhere else.