### PR TITLE
allow usb_reset on DfuIo / DfuAsyncIo to accept &mut self

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -37,7 +37,7 @@ pub trait DfuAsyncIo {
     ) -> impl Future<Output = Result<Self::Write, Self::Error>> + Send;
 
     /// Triggers a USB reset.
-    fn usb_reset(&self) -> impl Future<Output = Result<Self::Reset, Self::Error>> + Send;
+    fn usb_reset(&mut self) -> impl Future<Output = Result<Self::Reset, Self::Error>> + Send;
 
     /// Sleep for this duration of time.
     fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> + Send;

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -265,7 +265,7 @@ where
     }
 
     /// Reset the USB device
-    pub async fn usb_reset(&self) -> Result<IO::Reset, IO::Error> {
+    pub async fn usb_reset(&mut self) -> Result<IO::Reset, IO::Error> {
         self.io.usb_reset().await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait DfuIo {
     ) -> Result<Self::Write, Self::Error>;
 
     /// Triggers a USB reset.
-    fn usb_reset(&self) -> Result<Self::Reset, Self::Error>;
+    fn usb_reset(&mut self) -> Result<Self::Reset, Self::Error>;
 
     /// Returns the protocol of the device
     fn protocol(&self) -> &DfuProtocol<Self::MemoryLayout>;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -199,7 +199,7 @@ where
     }
 
     /// Reset the USB device
-    pub fn usb_reset(&self) -> Result<IO::Reset, IO::Error> {
+    pub fn usb_reset(&mut self) -> Result<IO::Reset, IO::Error> {
         self.io.usb_reset()
     }
 

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -414,7 +414,7 @@ impl dfu_core::asynchronous::DfuAsyncIo for MockIO {
         DfuIo::write_control(self, request_type, request, value, buffer)
     }
 
-    async fn usb_reset(&self) -> Result<Self::Reset, Self::Error> {
+    async fn usb_reset(&mut self) -> Result<Self::Reset, Self::Error> {
         DfuIo::usb_reset(self)
     }
 

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -365,7 +365,7 @@ impl DfuIo for MockIO {
         }
     }
 
-    fn usb_reset(&self) -> Result<Self::Reset, Self::Error> {
+    fn usb_reset(&mut self) -> Result<Self::Reset, Self::Error> {
         self.inner.lock().unwrap().was_reset = true;
         assert_eq!(
             self.state(),


### PR DESCRIPTION
Related: https://github.com/dfu-rs/dfu-nusb/issues/6

On macOS, `nusb` will fail to reset the device while interfaces are claimed. `DfuNusb` needs to explicitly drop the interface, and thus needs `&mut self`.