### PR TITLE
feat: add async download progress callback

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -121,6 +121,7 @@ where
     io: IO,
     dfu: DfuSansIo,
     buffer: Vec<u8>,
+    progress: Option<Box<dyn FnMut(usize) + Send>>,
 }
 
 impl<IO, E> DfuAsync<IO, E>
@@ -137,6 +138,7 @@ where
             io,
             dfu: DfuSansIo::new(descriptor),
             buffer: vec![0x00; transfer_size],
+            progress: None,
         }
     }
 
@@ -145,6 +147,12 @@ where
     /// This address is only used if the device uses the DfuSe protocol.
     pub fn override_address(&mut self, address: u32) -> &mut Self {
         self.dfu.set_address(address);
+        self
+    }
+
+    /// Use this closure to show progress.
+    pub fn with_progress(&mut self, progress: impl FnMut(usize) + Send + 'static) -> &mut Self {
+        self.progress = Some(Box::new(progress));
         self
     }
 
@@ -237,6 +245,9 @@ where
                     let (cmd, control) = cmd.download(chunk)?;
                     let n = control.execute_async(&self.io).await?;
                     reader.consume(n);
+                    if let Some(progress) = self.progress.as_mut() {
+                        progress(n);
+                    }
                     wait_status!(cmd)
                 }
                 download::Step::UsbReset => {

--- a/tests/download_async.rs
+++ b/tests/download_async.rs
@@ -90,6 +90,28 @@ async fn test_simple_download(mock: MockIO) {
 }
 
 #[test]
+async fn reports_progress() {
+    setup();
+
+    let mock = mock::MockIOBuilder::default().build();
+    let firmware = make_firmware(mock.size());
+    let cursor = TestCursor::new(&firmware);
+    let progress = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    let mut dfu = dfu_core::asynchronous::DfuAsync::new(mock);
+    let progress_clone = progress.clone();
+    dfu.with_progress(move |n| {
+        progress_clone.lock().unwrap().push(n);
+    });
+
+    dfu.download(cursor, firmware.len() as u32).await.unwrap();
+
+    let progress = progress.lock().unwrap();
+    assert_eq!(progress.iter().sum::<usize>(), firmware.len());
+    assert_eq!(progress.last(), Some(&0));
+}
+
+#[test]
 async fn no_will_detach_and_no_manifestation_toleration() {
     setup();
     let mock = mock::MockIOBuilder::default()


### PR DESCRIPTION
Implemented to use with my wasm web app + my dfu-webusb crate. Tested with STM32F405.
<img width="1256" height="158" alt="image" src="https://github.com/user-attachments/assets/ee388646-9911-4f3c-bf5a-326c8dfecb58" />
